### PR TITLE
Update prop type for closeButtonImage to fix #136

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -75,7 +75,7 @@ export default class CountryPicker extends Component {
     // to provide a functionality to disable/enable the onPress of Country Picker.
     disabled: PropTypes.bool,
     filterPlaceholderTextColor: PropTypes.string,
-    closeButtonImage: PropTypes.element,
+    closeButtonImage: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
     transparent: PropTypes.bool,
     animationType: PropTypes.oneOf(['slide', 'fade', 'none']),
     flagType: PropTypes.oneOf(Object.values(FLAG_TYPES)),


### PR DESCRIPTION
Set propTypes.closeButtonImage in CountryPicker.js to mirror the React Native ImageSource prop type (either number or {uri: ...} object)